### PR TITLE
tipo: mejoras en proyectos pendientes de aprobacion y asignacion

### DIFF
--- a/src/app/api/projects/route.ts
+++ b/src/app/api/projects/route.ts
@@ -203,6 +203,23 @@ export async function POST(request: Request) {
 
     const data = await request.json()
 
+    // Si es gerente general, verificar que la empresa pertenece al usuario
+    if (usuario.rol === 'GERENTE_GENERAL') {
+      const empresa = await prisma.empresaDesarrolladora.findFirst({
+        where: {
+          id: data.developerCompanyId,
+          representanteLegalId: usuario.id
+        }
+      })
+
+      if (!empresa) {
+        return NextResponse.json(
+          { error: 'No tienes permiso para crear proyectos en esta empresa' },
+          { status: 403 }
+        )
+      }
+    }
+
     // Mapear los campos del inglés al español
     const proyectoData = {
       nombre: data.name,

--- a/src/app/dashboard/projects/page.tsx
+++ b/src/app/dashboard/projects/page.tsx
@@ -111,7 +111,7 @@ export default function ProjectsPage() {
               className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-yellow-600 hover:bg-yellow-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-yellow-500"
             >
               <FiAlertCircle className="mr-2 h-5 w-5" />
-              Pendientes de Aprobación
+              Proyectos Pendientes
             </Link>
           )}
           <button

--- a/src/components/projects/components/DeveloperCompanySelect.tsx
+++ b/src/components/projects/components/DeveloperCompanySelect.tsx
@@ -1,5 +1,9 @@
 import { useState, useEffect } from 'react'
-import { DeveloperCompany } from '@/types/project'
+
+interface DeveloperCompany {
+  id: string
+  name: string
+}
 
 interface DeveloperCompanySelectProps {
   value: string
@@ -15,12 +19,17 @@ export default function DeveloperCompanySelect({ value, onChange, required }: De
   useEffect(() => {
     const fetchCompanies = async () => {
       try {
-        const response = await fetch('/api/developer-companies')
+        const response = await fetch('/api/empresas')
         if (!response.ok) {
           throw new Error('Error al cargar las empresas desarrolladoras')
         }
         const data = await response.json()
-        setCompanies(data)
+        // Transformar los datos al formato esperado
+        const formattedCompanies = data.map((company: any) => ({
+          id: company.id,
+          name: company.nombre
+        }))
+        setCompanies(formattedCompanies)
       } catch (error) {
         console.error('Error:', error)
         setError(error instanceof Error ? error.message : 'Error al cargar las empresas desarrolladoras')


### PR DESCRIPTION
Unificar las páginas de proyectos pendientes en una sola ruta /dashboard/projects/pending
Añadir un sistema de pestañas para alternar entre:
Pendientes de Aprobación
Pendientes de Asignación
Modificar la lógica para cargar los proyectos según la pestaña activa
Actualizar el botón en la página principal para que apunte a la nueva ruta unificada
Ahora el flujo será:
El gerente general ve un solo botón "Proyectos Pendientes" en la página principal
Al hacer clic, se abre la página unificada con dos pestañas:
En "Pendientes de Aprobación" puede ver y gestionar los proyectos que necesitan su aprobación
En "Pendientes de Asignación" puede ver y asignar gerentes a los proyectos aprobados